### PR TITLE
Added or updated to work on ubuntu 16.04

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,9 @@
 # defaults file for ansible-openldap
 openldap_admin_password: 'P@55w0rd'
 openldap_admin_user: 'admin'
-openldap_base: 'dc=example,dc=org'
+openldap_org: 'example'
+openldap_tld: 'org'
+openldap_base: 'dc={{ openldap_org }},dc={{ openldap_tld }}'
 openldap_bind_id: 'cn={{ openldap_bind_user }},{{ openldap_base }}'
 openldap_bind_user: '{{ openldap_admin_user }}'
 openldap_debian_packages:
@@ -28,4 +30,4 @@ openldap_users:
     password: 'P@55w0rd'
     loginShell: /bin/bash
     homeDirectory: /home/john
-pri_domain_name: 'example.org'
+pri_domain_name: '{{ openldap_org }}.{{ openldap_tld }}'

--- a/tasks/config_openldap.yml
+++ b/tasks/config_openldap.yml
@@ -23,6 +23,20 @@
     group: root
     mode: 0640
 
+- name: config_openldap | setting admin password
+  shell: slappasswd -s {{ openldap_admin_password }}
+  register: admin_password
+
+- name: config_openldap | restart slapd
+  systemd:
+    name: slapd
+    enabled: yes
+    daemon_reload: yes
+    state: restarted
+  when: >
+    admin_password is defined and
+    admin_password
+
 - name: config_openldap | populating openLDAP
   shell: 'ldapadd -x -D {{ openldap_bind_id }} -w {{ openldap_admin_password }} -f /etc/ldap/slapd.d/populate_content.ldif'
   ignore_errors: yes  #set to get around erroring out that items already exist

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -18,9 +18,15 @@
     - question: 'slapd/password1'
       value: '{{ openldap_admin_password }}'
       vtype: 'password'
+    - question: "slapd/domain"
+      value: "{{ pri_domain_name }}"
+      vtype: 'string'
+    - question: "shared/organization"
+      value: "{{ openldap_org }}"
+      vtype: 'string'
 
 - name: debian | installing packages
   apt:
     name: "{{ item }}"
     state: present
-  with_items: openldap_debian_packages
+  with_items: "{{ openldap_debian_packages }}"


### PR DESCRIPTION
tasks/debian.yml - Populating openLDAP task was failing due to permissions against the nodomain org. Added  slapd/domain and shared/organization to debconf to correct this
tasks/debian.yml - with_items clause needed {{}} to not error
tasks/config_openldap.yml - Added task to set admin password
tasls/config_openldap.yml - Added task to restart slapd