### PR TITLE
Use 'service' module instead of 'systemd' for greater compatibility

### DIFF
--- a/provision.sh
+++ b/provision.sh
@@ -2,6 +2,7 @@
 if [ -f /etc/debian_version ]; then
   sudo apt-get update
   sudo apt-get install -y git python-pip python-dev
+  sudo pip install --upgrade pip
 elif [ -f /etc/redhat-release ]; then
 #  rpm -iUvh http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-5.noarch.rpm
   yum install -y epel-release

--- a/tasks/config_openldap.yml
+++ b/tasks/config_openldap.yml
@@ -27,11 +27,21 @@
   shell: slappasswd -s {{ openldap_admin_password }}
   register: admin_password
 
+#- name: config_openldap | restart slapd
+#  systemd:
+#    name: slapd
+#    enabled: yes
+#    daemon_reload: yes
+#    state: restarted
+#  when: >
+#    admin_password is defined and
+#    admin_password
+
 - name: config_openldap | restart slapd
-  systemd:
+  service:
     name: slapd
     enabled: yes
-    daemon_reload: yes
+    #daemon_reload: yes
     state: restarted
   when: >
     admin_password is defined and


### PR DESCRIPTION
Full credit for these two fixes goes to @maruchi-usa, I'm just putting them in a PR so hopefully they get back to Galaxy.

* Using the `system` module instead of `systemd` is more compatible, it works on both Trusty and Xenial.
* The version of pip that ships with Trusty doesn't seem to be compatible with newer versions of Ansible.  Upgrading pip with the latest version from PyPi seems to fix it.

I've QA'ed these changes using the local Vagrant build.