### PR TITLE
Testing multiple OS via Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,29 +1,34 @@
 ---
-language: python
-python: "2.7"
+sudo: required
 
-# Use the new container infrastructure
-sudo: false
+env:
+  - distribution: ubuntu
+    version: trusty
+  - distribution: ubuntu
+    version: xenial
+  - distribution: ubuntu
+    version: bionic
 
-# Install ansible
-addons:
-  apt:
-    packages:
-    - python-pip
+services:
+  - docker
 
-install:
-  # Install ansible
-  - pip install ansible
-
-  # Check ansible version
-  - ansible --version
-
-  # Create ansible.cfg with correct roles_path
-  - printf '[defaults]\nroles_path=../' >ansible.cfg
+before_install:
+  - 'sudo docker pull ${distribution}:${version}'
+  - 'sudo docker build --no-cache --rm --file=travis/${distribution}-${version}.Dockerfile --tag=${distribution}-${version}:ansible travis'
 
 script:
-  # Basic role syntax check
-  - ansible-playbook tests/test.yml -i tests/inventory --syntax-check
+  - container_id=$(mktemp)
+  - 'sudo docker run --detach --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro --volume="${PWD}":/etc/ansible/roles/ansible-openldap:ro ${distribution}-${version}:ansible > "${container_id}"'
+  - 'sudo docker exec "$(cat ${container_id})" env ANSIBLE_FORCE_COLOR=1 ansible-playbook -v /etc/ansible/roles/ansible-openldap/tests/test.yml --syntax-check'
+  - 'sudo docker exec "$(cat ${container_id})" env ANSIBLE_FORCE_COLOR=1 ansible-playbook -v /etc/ansible/roles/ansible-openldap/tests/test.yml'
+  
+  ## This block runs the test.yml a second time and checks if Ansible reports a change was made during the
+  #   second playbook run.  Effectivly, it fails the test if the playbook isn't idempotent.  Disabling for
+  #   now since it fails.
+  # - >
+  #   sudo docker exec "$(cat ${container_id})" env ANSIBLE_FORCE_COLOR=1 ansible-playbook -v /etc/ansible/roles/ansible-openldap/tests/test.yml
+  #   | grep -q 'changed=0.*failed=0'
+  #   && (echo 'Idempotence test: pass' && exit 0)
+  #   || (echo 'Idempotence test: fail' && exit 1)
 
-notifications:
-  webhooks: https://galaxy.ansible.com/api/v1/notifications/
+  - 'sudo docker rm -f "$(cat ${container_id})"'

--- a/provision.sh
+++ b/provision.sh
@@ -2,6 +2,7 @@
 if [ -f /etc/debian_version ]; then
   sudo apt-get update
   sudo apt-get install -y git python-pip python-dev
+  sudo pip install --upgrade pip
 elif [ -f /etc/redhat-release ]; then
 #  rpm -iUvh http://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-5.noarch.rpm
   yum install -y epel-release

--- a/tasks/config_openldap.yml
+++ b/tasks/config_openldap.yml
@@ -27,11 +27,21 @@
   shell: slappasswd -s {{ openldap_admin_password }}
   register: admin_password
 
+#- name: config_openldap | restart slapd
+#  systemd:
+#    name: slapd
+#    enabled: yes
+#    daemon_reload: yes
+#    state: restarted
+#  when: >
+#    admin_password is defined and
+#    admin_password
+
 - name: config_openldap | restart slapd
-  systemd:
+  service:
     name: slapd
     enabled: yes
-    daemon_reload: yes
+    #daemon_reload: yes
     state: restarted
   when: >
     admin_password is defined and

--- a/travis/ubuntu-bionic.Dockerfile
+++ b/travis/ubuntu-bionic.Dockerfile
@@ -1,0 +1,19 @@
+FROM ubuntu:bionic
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get dist-upgrade -y && \
+    apt-get install -y software-properties-common && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN apt-add-repository -y ppa:ansible/ansible && \
+    apt-get update && apt-get install -y \
+        init \
+        git \
+        ansible \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN echo "[local]\nlocalhost ansible_connection=local" > /etc/ansible/hosts
+
+ENTRYPOINT ["/sbin/init"]

--- a/travis/ubuntu-trusty.Dockerfile
+++ b/travis/ubuntu-trusty.Dockerfile
@@ -1,0 +1,18 @@
+FROM ubuntu:trusty
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get dist-upgrade -y && \
+    apt-get install -y software-properties-common && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN apt-add-repository -y ppa:ansible/ansible && \
+    apt-get update && apt-get install -y \
+        git \
+        ansible \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN echo "[local]\nlocalhost ansible_connection=local" > /etc/ansible/hosts
+
+ENTRYPOINT ["/sbin/init"]

--- a/travis/ubuntu-xenial.Dockerfile
+++ b/travis/ubuntu-xenial.Dockerfile
@@ -1,0 +1,18 @@
+FROM ubuntu:xenial
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get dist-upgrade -y && \
+    apt-get install -y software-properties-common && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN apt-add-repository -y ppa:ansible/ansible && \
+    apt-get update && apt-get install -y \
+        git \
+        ansible \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN echo "[local]\nlocalhost ansible_connection=local" > /etc/ansible/hosts
+
+ENTRYPOINT ["/sbin/init"]


### PR DESCRIPTION
I am interested in being able to use this role on both Ubuntu Xenial and Trusty, so I made some changes to the .travis.yml file to expand the testing surface.  In parallel, it runs the tests in Trusty, Xenial, and Bionic environments.

Is this something you are interested in accepting into master?