### PR TITLE
Fix missing php-xml issue

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,6 +10,7 @@ openldap_bind_user: '{{ openldap_admin_user }}'
 openldap_debian_packages:
   - slapd
   - ldap-utils
+  - php-xml
   - phpldapadmin
 openldap_organizationalunits:  #defines OU's to populate
   - People


### PR DESCRIPTION
This fix the issue, the openldapadmin miss the php-xml library