### PR TITLE
Making phpldapadmin config optional

### DIFF
--- a/tasks/config_openldap.yml
+++ b/tasks/config_openldap.yml
@@ -16,6 +16,7 @@
     group: www-data
     mode: 0640
   become: true
+  when: '"phpldapadmin" in openldap_debian_packages'
 
 - name: config_openldap | creating database population config
   template:


### PR DESCRIPTION
That is, if ldapadmin is not installed, it should not be configured
Also, phpldapadmin is not available in Debian Buster repositories