### PR TITLE
Extending LDAP schema

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -53,3 +53,17 @@ openldap_users:
     homeDirectory: /home/john
 
 openldap_tld: org
+
+# Define a set of schema specifications files. 
+# For a non basic schema, Its .schema file must be placed in files/openldap/schema/. This file will be copied and converted to ldif before being inserted to LDAP tree
+openldap_schemas:
+  - core
+  - cosine
+  - inetorgperson
+  - nis
+
+# Define DB Engine (mdb / hdb)
+openldap_db_engine: MDB
+
+# Temp files path
+openldap_ldif_tmp_dir: /tmp/ldifs

--- a/tasks/config_openldap.yml
+++ b/tasks/config_openldap.yml
@@ -18,6 +18,10 @@
   become: true
   when: '"phpldapadmin" in openldap_debian_packages'
 
+- name: config_openldap | extending LDAP Schema
+  include_tasks: config_openldap_schemas.yml
+  when: openldap_schemas|length > 0
+
 - name: config_openldap | creating database population config
   template:
     src: etc/ldap/slapd.d/populate_content.ldif.j2

--- a/tasks/config_openldap_schemas.yml
+++ b/tasks/config_openldap_schemas.yml
@@ -1,0 +1,45 @@
+---
+- name: config_openldap_schemas | copying schemas files
+  copy:
+    src: '{{ item }}'
+    dest: '/etc/ldap/schema/'
+    owner: 'root'
+    group: 'root'
+    mode: '0640'
+  with_fileglob:
+    - 'files/openldap/schema/*.schema'
+  become: true
+
+- name: config_openldap_schemas | creating temp folder
+  file:
+    path: '{{ openldap_ldif_tmp_dir }}'
+    state: directory
+    owner: 'root'
+    group: 'root'
+    mode: '0640'
+  become: true
+
+- name: config_openldap_schemas | creating a conversion file
+  template:
+    src: etc/ldap/slapd.d/schema_conversion.conf.j2
+    dest: '{{ openldap_ldif_tmp_dir }}/schema_conversion.conf'
+    owner: root
+    group: root
+    mode: 0644
+  become: true
+
+- name: config_openldap_schemas | covertyng *.schema to *.ldif
+  command: slaptest -f {{ openldap_ldif_tmp_dir }}/schema_conversion.conf -F {{ openldap_ldif_tmp_dir }}
+
+- name: config_openldap_schemas | adding new schemas
+  include_tasks: "config_openldap_schemas_ldifs.yml"
+  with_items: "{{openldap_schemas}}"
+  loop_control:
+    loop_var: schema
+
+- name: config_openldap_schemas | deleting temp folder
+  file:
+    path: '{{ openldap_ldif_tmp_dir }}'
+    state: absent
+  become: true
+

--- a/tasks/config_openldap_schemas_ldifs.yml
+++ b/tasks/config_openldap_schemas_ldifs.yml
@@ -1,0 +1,30 @@
+---
+- name: config_openldap_schemas_ldfis | getting converted *.ldif
+  find:
+    paths: '{{ openldap_ldif_tmp_dir }}/cn=config/cn=schema/'
+    patterns: '*{{ schema }}.ldif'
+  register: converted_ldif
+
+- name: config_openldap_schemas_ldfis | correcting dn in ldif
+  lineinfile:
+    path: "{{ converted_ldif.files[0].path }}"
+    regexp: "^dn: cn={[0-9]*}{{schema}}$"
+    line: "dn: cn={{schema}},cn=schema,cn=config"
+
+- name: config_openldap_schemas_ldfis | correcting cn in ldif
+  lineinfile:
+    path: "{{ converted_ldif.files[0].path }}"
+    regexp: "^cn: {[0-9]*}{{schema}}$"
+    line: "cn: {{schema}}"
+
+- name: config_openldap_schemas_ldfis | removing file lines in ldif
+  lineinfile:
+    path: "{{ converted_ldif.files[0].path }}"
+    regexp: "^{{item}}"
+    state: "absent"
+  with_items: ["structuralObjectClass:","entryUUID:","creatorsName:","createTimestamp:","entryCSN:","modifiersName:","modifyTimestamp:"]
+
+- name: config_openldap_schemas_ldfis | adding new schema to LDAP tree
+  command: ldapadd -Y EXTERNAL -H ldapi:/// -f {{ converted_ldif.files[0].path }}
+  ignore_errors: yes #fails on duplicate
+

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -27,6 +27,9 @@
     - question: shared/organization
       value: "{{ openldap_org }}"
       vtype: string
+    - question: slapd/backend
+      value: "{{ openldap_db_engine }}"
+      vtype: string
 
 - name: debian | installing packages
   apt:

--- a/templates/etc/ldap/slapd.d/schema_conversion.conf.j2
+++ b/templates/etc/ldap/slapd.d/schema_conversion.conf.j2
@@ -1,0 +1,3 @@
+{% for schema in openldap_schemas %}
+include		/etc/ldap/schema/{{ schema }}.schema
+{% endfor %}


### PR DESCRIPTION
For a non basic schema, Its .schema file must be placed in files/openldap/schema/. This file will be copied and converted to ldif before being inserted to LDAP tree