### PR TITLE
Make ansible-lint more happy with spaces before and after variable names

### DIFF
--- a/tasks/config_openldap_schemas.yml
+++ b/tasks/config_openldap_schemas.yml
@@ -33,7 +33,7 @@
 
 - name: config_openldap_schemas | adding new schemas
   include_tasks: "config_openldap_schemas_ldifs.yml"
-  with_items: "{{openldap_schemas}}"
+  with_items: "{{ openldap_schemas }}"
   loop_control:
     loop_var: schema
 

--- a/tasks/config_openldap_schemas_ldifs.yml
+++ b/tasks/config_openldap_schemas_ldifs.yml
@@ -8,19 +8,19 @@
 - name: config_openldap_schemas_ldfis | correcting dn in ldif
   lineinfile:
     path: "{{ converted_ldif.files[0].path }}"
-    regexp: "^dn: cn={[0-9]*}{{schema}}$"
-    line: "dn: cn={{schema}},cn=schema,cn=config"
+    regexp: "^dn: cn={[0-9]*}{{ schema }}$"
+    line: "dn: cn={{ schema }},cn=schema,cn=config"
 
 - name: config_openldap_schemas_ldfis | correcting cn in ldif
   lineinfile:
     path: "{{ converted_ldif.files[0].path }}"
-    regexp: "^cn: {[0-9]*}{{schema}}$"
-    line: "cn: {{schema}}"
+    regexp: "^cn: {[0-9]*}{{ schema }}$"
+    line: "cn: {{ schema }}"
 
 - name: config_openldap_schemas_ldfis | removing file lines in ldif
   lineinfile:
     path: "{{ converted_ldif.files[0].path }}"
-    regexp: "^{{item}}"
+    regexp: "^{{ item }}"
     state: "absent"
   with_items: ["structuralObjectClass:","entryUUID:","creatorsName:","createTimestamp:","entryCSN:","modifiersName:","modifyTimestamp:"]
 


### PR DESCRIPTION
Due to ansible-lint errors the role has not such a great score (2.5) on ansible-galaxy. I fixed the problem with the spaces after and before variable names. For example now it's `{{ openldap_schemas }}` instaed of `{{openldap_schemas}}`.