### PR TITLE
refactor: modernize module references to FQCN

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,7 +1,7 @@
 ---
 # handlers file for ansible-openldap
 - name: restart slapd
-  service:
+  ansible.builtin.service:
     name: slapd
     state: restarted
   become: true

--- a/tasks/config_openldap.yml
+++ b/tasks/config_openldap.yml
@@ -1,6 +1,6 @@
 ---
 - name: config_openldap | configuring ldap
-  template:
+  ansible.builtin.template:
     src: etc/ldap/ldap.conf.j2
     dest: /etc/ldap/ldap.conf
     owner: root
@@ -9,7 +9,7 @@
   become: true
 
 - name: config_openldap | configuring phpldapadmin
-  template:
+  ansible.builtin.template:
     src: etc/phpldapadmin/config.php.j2
     dest: /etc/phpldapadmin/config.php
     owner: root
@@ -19,7 +19,7 @@
   when: '"phpldapadmin" in openldap_debian_packages'
 
 - name: config_openldap | creating temp folder
-  file:
+  ansible.builtin.file:
     path: '{{ openldap_ldif_tmp_dir }}'
     state: directory
     owner: 'root'
@@ -28,23 +28,23 @@
   become: true
 
 - name: config_openldap | extending LDAP Schema
-  include_tasks: config_openldap_schemas.yml
+  ansible.builtin.include_tasks: config_openldap_schemas.yml
   when: openldap_schemas|length > 0
 
 - name: config_openldap | managing overlays
-  include_tasks: config_openldap_overlays.yml
+  ansible.builtin.include_tasks: config_openldap_overlays.yml
   with_items: "{{ openldap_overlays_and_acls }}"
   loop_control:
     loop_var: overlay
 
 - name: config_openldap | deleting temp folder
-  file:
+  ansible.builtin.file:
     path: '{{ openldap_ldif_tmp_dir }}'
     state: absent
   become: true
 
 - name: config_openldap | creating database population config
-  template:
+  ansible.builtin.template:
     src: etc/ldap/slapd.d/populate_content.ldif.j2
     dest: /etc/ldap/slapd.d/populate_content.ldif
     owner: root
@@ -53,12 +53,12 @@
   become: true
 
 - name: config_openldap | setting admin password # noqa 301 305
-  shell: slappasswd -s {{ openldap_admin_password }}
+  ansible.builtin.shell: slappasswd -s {{ openldap_admin_password }}
   register: _openldap_admin_password
   become: true
 
 - name: config_openldap | restart slapd
-  service:
+  ansible.builtin.service:
     name: slapd
     enabled: true
     state: restarted
@@ -68,7 +68,7 @@
 # Ignore errors to get around erroring out that items already exist
 # This needs to be more idempotent
 - name: config_openldap | populating openLDAP # noqa 305
-  shell: "ldapadd -x -D {{ openldap_bind_id }} -w {{ openldap_admin_password }} -f /etc/ldap/slapd.d/populate_content.ldif"
+  ansible.builtin.shell: "ldapadd -x -D {{ openldap_bind_id }} -w {{ openldap_admin_password }} -f /etc/ldap/slapd.d/populate_content.ldif"
   ignore_errors: true
   when:
     - openldap_populate is defined

--- a/tasks/config_openldap_overlays.yml
+++ b/tasks/config_openldap_overlays.yml
@@ -1,6 +1,6 @@
 ---
 - name: config_openldap_overlays | copying ldif files
-  copy:
+  ansible.builtin.copy:
     src: 'files/openldap/overlays/{{ item.path }}'
     dest: '{{ openldap_ldif_tmp_dir }}/{{ item.path }}'
     owner: 'root'
@@ -10,7 +10,7 @@
   with_items: "{{overlay.ldifs}}"
 
 - name: config_openldap_overlays | applying or configuring overlay
-  command: "ldap{{item.action}} -Y EXTERNAL -H ldapi:/// -f {{ openldap_ldif_tmp_dir }}/{{ item.path }}"
+  ansible.builtin.command: "ldap{{item.action}} -Y EXTERNAL -H ldapi:/// -f {{ openldap_ldif_tmp_dir }}/{{ item.path }}"
   ignore_errors: yes #fails on duplicate
   with_items: "{{overlay.ldifs}}"
 

--- a/tasks/config_openldap_schemas.yml
+++ b/tasks/config_openldap_schemas.yml
@@ -1,6 +1,6 @@
 ---
 - name: config_openldap_schemas | copying schemas files
-  copy:
+  ansible.builtin.copy:
     src: '{{ item }}'
     dest: '/etc/ldap/schema/'
     owner: 'root'
@@ -11,7 +11,7 @@
   become: true
 
 - name: config_openldap_schemas | creating a conversion file
-  template:
+  ansible.builtin.template:
     src: etc/ldap/slapd.d/schema_conversion.conf.j2
     dest: '{{ openldap_ldif_tmp_dir }}/schema_conversion.conf'
     owner: root
@@ -20,10 +20,10 @@
   become: true
 
 - name: config_openldap_schemas | covertyng *.schema to *.ldif
-  command: slaptest -f {{ openldap_ldif_tmp_dir }}/schema_conversion.conf -F {{ openldap_ldif_tmp_dir }}
+  ansible.builtin.command: slaptest -f {{ openldap_ldif_tmp_dir }}/schema_conversion.conf -F {{ openldap_ldif_tmp_dir }}
 
 - name: config_openldap_schemas | adding new schemas
-  include_tasks: "config_openldap_schemas_ldifs.yml"
+  ansible.builtin.include_tasks: "config_openldap_schemas_ldifs.yml"
   with_items: "{{ openldap_schemas }}"
   loop_control:
     loop_var: schema

--- a/tasks/config_openldap_schemas_ldifs.yml
+++ b/tasks/config_openldap_schemas_ldifs.yml
@@ -1,30 +1,30 @@
 ---
 - name: config_openldap_schemas_ldfis | getting converted *.ldif
-  find:
+  ansible.builtin.find:
     paths: '{{ openldap_ldif_tmp_dir }}/cn=config/cn=schema/'
     patterns: '*{{ schema }}.ldif'
   register: converted_ldif
 
 - name: config_openldap_schemas_ldfis | correcting dn in ldif
-  lineinfile:
+  ansible.builtin.lineinfile:
     path: "{{ converted_ldif.files[0].path }}"
     regexp: "^dn: cn={[0-9]*}{{ schema }}$"
     line: "dn: cn={{ schema }},cn=schema,cn=config"
 
 - name: config_openldap_schemas_ldfis | correcting cn in ldif
-  lineinfile:
+  ansible.builtin.lineinfile:
     path: "{{ converted_ldif.files[0].path }}"
     regexp: "^cn: {[0-9]*}{{ schema }}$"
     line: "cn: {{ schema }}"
 
 - name: config_openldap_schemas_ldfis | removing file lines in ldif
-  lineinfile:
+  ansible.builtin.lineinfile:
     path: "{{ converted_ldif.files[0].path }}"
     regexp: "^{{ item }}"
     state: "absent"
   with_items: ["structuralObjectClass:","entryUUID:","creatorsName:","createTimestamp:","entryCSN:","modifiersName:","modifyTimestamp:"]
 
 - name: config_openldap_schemas_ldfis | adding new schema to LDAP tree
-  command: ldapadd -Y EXTERNAL -H ldapi:/// -f {{ converted_ldif.files[0].path }}
+  ansible.builtin.command: ldapadd -Y EXTERNAL -H ldapi:/// -f {{ converted_ldif.files[0].path }}
   ignore_errors: yes #fails on duplicate
 

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -1,6 +1,6 @@
 ---
 - name: debian | ensure debconf-utils is installed
-  apt:
+  ansible.builtin.apt:
     name: debconf-utils
     state: present
     update_cache: true
@@ -10,7 +10,7 @@
   until: result is successful
 
 - name: debian | definining openldap install settings
-  debconf:
+  ansible.builtin.debconf:
     name: slapd
     question: "{{ item['question'] }}"
     value: "{{ item['value'] }}"
@@ -42,7 +42,7 @@
       vtype: string
 
 - name: debian | installing packages
-  apt:
+  ansible.builtin.apt:
     name: "{{ openldap_debian_packages }}"
     state: present
     update_cache: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 # tasks file for ansible-openldap
-- include_tasks: debian.yml
+- ansible.builtin.include_tasks: debian.yml
   when: ansible_os_family == "Debian"
 
-- include_tasks: config_openldap.yml
+- ansible.builtin.include_tasks: config_openldap.yml
   when: openldap_config|bool


### PR DESCRIPTION
## Summary

Refs #17 (second follow-up round, scoped in a comment on that issue). Converts every short-form module reference in `tasks/*.yml` and `handlers/*.yml` to fully-qualified collection names (`ansible.builtin.*`), per current Ansible best practice and ansible-lint's `fqcn` rule.

- `tasks/debian.yml`: `apt` (x2), `debconf`
- `tasks/config_openldap.yml`: `template` (x3), `file` (x2), `shell` (x2), `service`, `include_tasks` (x2)
- `tasks/config_openldap_schemas.yml`: `copy`, `template`, `command`, `include_tasks`
- `tasks/config_openldap_schemas_ldifs.yml`: `find`, `lineinfile` (x3), `command`
- `tasks/config_openldap_overlays.yml`: `copy`, `command`
- `tasks/main.yml`: `include_tasks` (x2)
- `handlers/main.yml`: `service`

All 27 module actions are core `ansible.builtin` modules -- no community collections needed. Pure renaming pass: no task names, `when:` conditions, module arguments, task ordering, or handler names changed. Diff is line-for-line 1:1 (27 insertions / 27 deletions across 7 files).

## Verification

- `ansible-lint --fix=fqcn` was attempted first but refused to run (this repo's `.yamllint` has an incompatible `octal-values` config for ansible-lint's fix mode) -- left untouched per scope, and applied every rename by hand instead.
- Grepped `tasks/*.yml` and `handlers/*.yml` after the change for `apt|service|template|copy|file|command|shell|debconf|lineinfile|find|include_tasks` as bare module keys: zero matches.
- Full-repo `ansible-lint` run: `fqcn` findings dropped from 36 to 9. The remaining 9 are all in `molecule/*/verify.yml` and `molecule/shared/converge.yml`, which are out of scope here (noted for a separate follow-up, not fixed opportunistically).
- Ran `molecule test` for all 5 scenarios natively on Apple Silicon, now possible since PR #18 switched the role to multi-arch `mrlesmithjr/*` Docker images. All 5 passed the full cycle (dependency/destroy/syntax/create/converge/idempotence/verify/destroy), including a clean idempotence run (`changed=0` on the second converge) on every scenario -- confirming the FQCN rename didn't reintroduce the debconf/apt idempotency issue from the last round:
  - `debian12`: pass
  - `ubuntu2204`: pass
  - `ubuntu2404`: pass
  - `fedora`: pass
  - `rocky9`: pass

## Follow-up (intentionally out of scope here)

- FQCN cleanup for `molecule/*/verify.yml` (`assert`) and `molecule/shared/converge.yml` (`include_role`) -- 9 remaining ansible-lint `fqcn` findings, all outside `tasks/`/`handlers/`.
- This repo has no `.ansible-lint` config file (despite the earlier assumption that one exists) -- ansible-lint runs entirely on its built-in defaults here. Worth confirming intentionally, or adding one, in a separate pass.

## Test plan

- [x] `ansible-lint` shows zero `fqcn` findings in `tasks/` and `handlers/`
- [x] `molecule test --scenario-name debian12` passes (full cycle + idempotence)
- [x] `molecule test --scenario-name ubuntu2204` passes (full cycle + idempotence)
- [x] `molecule test --scenario-name ubuntu2404` passes (full cycle + idempotence)
- [x] `molecule test --scenario-name fedora` passes (full cycle + idempotence)
- [x] `molecule test --scenario-name rocky9` passes (full cycle + idempotence)